### PR TITLE
`org.openrewrite.gradle.Assertions#withToolingModel` moved to `org.openrewrite.gradle.toolingapi.Assertions`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-gradle")
+    testImplementation("org.openrewrite.gradle.tooling:model:$rewriteVersion")
     testImplementation("org.openrewrite:rewrite-maven")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")

--- a/src/test/java/org/openrewrite/launchdarkly/UpgradeLaunchDarkly6Test.java
+++ b/src/test/java/org/openrewrite/launchdarkly/UpgradeLaunchDarkly6Test.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class UpgradeLaunchDarkly6Test implements RewriteTest {

--- a/src/test/java/org/openrewrite/launchdarkly/UpgradeLaunchDarkly7Test.java
+++ b/src/test/java/org/openrewrite/launchdarkly/UpgradeLaunchDarkly7Test.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class UpgradeLaunchDarkly7Test implements RewriteTest {


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.ChangeMethodTargetToStatic?organizationId=T3BlblJld3JpdGU%3D