### PR TITLE
Prevent TraitErrors seen with custom method pattern

### DIFF
--- a/src/main/java/org/openrewrite/launchdarkly/ChangeVariationDefault.java
+++ b/src/main/java/org/openrewrite/launchdarkly/ChangeVariationDefault.java
@@ -69,25 +69,24 @@ public class ChangeVariationDefault extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
                 Expression firstArgument = mi.getArguments().get(0);
-                boolean isFirstArgumentFeatureKey = isFeatureKey(firstArgument);
                 Expression lastArgument = mi.getArguments().get(mi.getArguments().size() - 1);
-                if (BOOL_VARIATION_MATCHER.matches(mi) && isFirstArgumentFeatureKey) {
+                if (BOOL_VARIATION_MATCHER.matches(mi) && isFeatureKey(firstArgument)) {
                     return changeValue(mi, lastArgument, new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, defaultValue, defaultValue, null, JavaType.Primitive.Boolean));
                 }
-                if (STRING_VARIATION_MATCHER.matches(mi) && isFirstArgumentFeatureKey) {
+                if (STRING_VARIATION_MATCHER.matches(mi) && isFeatureKey(firstArgument)) {
                     return changeValue(mi, lastArgument, new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, defaultValue, "\"" + defaultValue + "\"", null, JavaType.Primitive.String));
                 }
-                if (INT_VARIATION_MATCHER.matches(mi) && isFirstArgumentFeatureKey) {
+                if (INT_VARIATION_MATCHER.matches(mi) && isFeatureKey(firstArgument)) {
                     return changeValue(mi, lastArgument, new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, defaultValue, defaultValue, null, JavaType.Primitive.Int));
                 }
-                if (DOUBLE_VARIATION_MATCHER.matches(mi) && isFirstArgumentFeatureKey) {
+                if (DOUBLE_VARIATION_MATCHER.matches(mi) && isFeatureKey(firstArgument)) {
                     return changeValue(mi, lastArgument, new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, defaultValue, defaultValue, null, JavaType.Primitive.Double));
                 }
                 return mi;
             }
 
             private Boolean isFeatureKey(Expression firstArgument) {
-                return J.Literal.isLiteralValue(firstArgument, featureKey) || CursorUtil.findCursorForTree(getCursor(), firstArgument)
+                return CursorUtil.findCursorForTree(getCursor(), firstArgument)
                         .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
                         .map(featureKey::equals)
                         .orSome(false);

--- a/src/main/java/org/openrewrite/launchdarkly/RemoveBoolVariation.java
+++ b/src/main/java/org/openrewrite/launchdarkly/RemoveBoolVariation.java
@@ -25,6 +25,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
@@ -77,19 +78,21 @@ public class RemoveBoolVariation extends Recipe {
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-                boolean isFirstArgumentFeatureKey =
-                        CursorUtil
-                                .findCursorForTree(getCursor(), mi.getArguments().get(0))
-                                .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
-                                .map(featureKey::equals)
-                                .orSome(false);
-                if (methodMatcher.matches(mi) && isFirstArgumentFeatureKey) {
+                if (methodMatcher.matches(mi) && isFeatureKey(mi.getArguments().get(0))) {
                     doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
                     doAfterVisit(new RemoveUnusedLocalVariables(null).getVisitor());
                     doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
                     return new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, String.valueOf(replacementValue), null, JavaType.Primitive.Boolean);
                 }
                 return mi;
+            }
+
+            private boolean isFeatureKey(Expression firstArgument) {
+                return J.Literal.isLiteralValue(firstArgument, featureKey) ||
+                       CursorUtil.findCursorForTree(getCursor(), firstArgument)
+                               .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
+                               .map(featureKey::equals)
+                               .orSome(false);
             }
         };
         return Preconditions.check(new UsesMethod<>(methodMatcher), visitor);

--- a/src/main/java/org/openrewrite/launchdarkly/RemoveBoolVariation.java
+++ b/src/main/java/org/openrewrite/launchdarkly/RemoveBoolVariation.java
@@ -88,8 +88,7 @@ public class RemoveBoolVariation extends Recipe {
             }
 
             private boolean isFeatureKey(Expression firstArgument) {
-                return J.Literal.isLiteralValue(firstArgument, featureKey) ||
-                       CursorUtil.findCursorForTree(getCursor(), firstArgument)
+                return CursorUtil.findCursorForTree(getCursor(), firstArgument)
                                .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
                                .map(featureKey::equals)
                                .orSome(false);


### PR DESCRIPTION
## What's changed?
Add a unit test that failed to replicate #23.
Add defensive coding to not call `CursorUtil` unnecessarily.

## What's your motivation?
Try to replicate #23 
- #23 

## Anything in particular you'd like reviewers to focus on?
Not quite sure what's triggering the `TraitErrors` in #23, but this should at least prevent that for the simplest cases, providing immediate relief without diving into rewrite-analysis just yet, which could take up a lot more time.