### PR TITLE
Remove String feature flags for LaunchDarkly

### DIFF
--- a/src/main/java/org/openrewrite/featureflags/RemoveStringFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveStringFlag.java
@@ -34,7 +34,7 @@ import org.openrewrite.staticanalysis.SimplifyConstantIfBranchExecution;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class RemoveBooleanFlag extends Recipe {
+public class RemoveStringFlag extends Recipe {
 
     @Override
     public String getDisplayName() {
@@ -58,8 +58,8 @@ public class RemoveBooleanFlag extends Recipe {
 
     @Option(displayName = "Replacement value",
             description = "The value to replace the feature flag check with.",
-            example = "true")
-    Boolean replacementValue;
+            example = "topic-456")
+    String replacementValue;
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -72,7 +72,7 @@ public class RemoveBooleanFlag extends Recipe {
                     doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
                     doAfterVisit(new RemoveUnusedLocalVariables(null).getVisitor());
                     doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
-                    J.Literal literal = new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, String.valueOf(replacementValue), null, JavaType.Primitive.Boolean);
+                    J.Literal literal = new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, '"' + replacementValue + '"', null, JavaType.Primitive.String);
                     return literal.withPrefix(mi.getPrefix());
                 }
                 return mi;

--- a/src/main/java/org/openrewrite/featureflags/launchdarkly/RemoveStringVariation.java
+++ b/src/main/java/org/openrewrite/featureflags/launchdarkly/RemoveStringVariation.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.launchdarkly;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.featureflags.RemoveBooleanFlag;
+import org.openrewrite.featureflags.RemoveStringFlag;
+
+import java.util.Collections;
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RemoveStringVariation extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove LaunchDarkly's `boolVariation` for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `boolVariation` invocations for feature key with value, and simplify constant if branch execution.";
+    }
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "topic-456")
+    String replacementValue;
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return Collections.singletonList(new RemoveStringFlag(
+                "com.launchdarkly.sdk.server.LDClient stringVariation(String, com.launchdarkly.sdk.*, String)",
+                featureKey, replacementValue));
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/RemoveBooleanFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/RemoveBooleanFlagTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.featureflags;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
@@ -25,6 +26,7 @@ import static org.openrewrite.java.Assertions.java;
 class RemoveBooleanFlagTest implements RewriteTest {
 
     @Test
+    @DocumentExample
     void customMethodPatternForWrapper() {
         rewriteRun(
           spec -> spec.recipe(new RemoveBooleanFlag("com.acme.bank.CustomLaunchDarklyWrapper featureFlagEnabled(String, boolean)", "flag-key-123abc", true)),

--- a/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveStringFlagTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveStringFlag("com.acme.bank.InHouseFF getStringFeatureFlagValue(String, String)", "flag-key-123abc", "topic-456"))
+          // language=java
+          .parser(JavaParser.fromJavaVersion().dependsOn(
+            """
+              package com.acme.bank;
+              public class InHouseFF {
+                  public String getStringFeatureFlagValue(String key, String fallback) {
+                      return fallback;
+                  }
+              }
+              """
+          ));
+    }
+
+    @DocumentExample
+    @Test
+    void removeStringFeatureFlag() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveStringFlag("com.acme.bank.InHouseFF getStringFeatureFlagValue(String, String)", "flag-key-123abc", "topic-456")),
+          // language=java
+          java(
+            """
+              import com.acme.bank.InHouseFF;
+              class Foo {
+                  private InHouseFF inHouseFF = new InHouseFF();
+                  void bar() {
+                      String topic = inHouseFF.getStringFeatureFlagValue("flag-key-123abc", "topic-123");
+                      System.out.println("Publishing to topic: " + topic);
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      String topic = "topic-456";
+                      System.out.println("Publishing to topic: " + topic);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Disabled("This test is disabled because it is not yet implemented.")
+    @Test
+    void removeEqualsComparison() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveStringFlag("com.acme.bank.InHouseFF getStringFeatureFlagValue(String, String)", "flag-key-123abc", "topic-456")),
+          // language=java
+          java(
+            """
+              import com.acme.bank.InHouseFF;
+              class Foo {
+                  private InHouseFF inHouseFF = new InHouseFF();
+                  void bar() {
+                      if ("topic-456".equals(inHouseFF.getStringFeatureFlagValue("flag-key-123abc", "topic-123"))) {
+                          // Application code to show the feature
+                          System.out.println("Feature is on");
+                      }
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      // Application code to show the feature
+                      System.out.println("Feature is on");
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
 import static org.openrewrite.java.Assertions.java;
 
 class RemoveStringFlagTest implements RewriteTest {

--- a/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
@@ -21,8 +21,6 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.SourceSpec;
-
 import static org.openrewrite.java.Assertions.java;
 
 class RemoveStringFlagTest implements RewriteTest {

--- a/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveStringVariationTest.java
+++ b/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveStringVariationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.launchdarkly;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveStringVariationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveStringVariation("flag-key-123abc", "topic-456"))
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "launchdarkly-java-server-sdk-6"));
+    }
+
+    @Test
+    @DocumentExample
+    void replaceStringVariation() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import com.launchdarkly.sdk.LDContext;
+              import com.launchdarkly.sdk.server.LDClient;
+              class Foo {
+                  private LDClient client = new LDClient("sdk-key-123abc");
+                  void bar() {
+                      LDContext context = null;
+                      String topic = client.stringVariation("flag-key-123abc", context, "topic-123");
+                      System.out.println("Publishing to topic: " + topic);
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      String topic = "topic-456";
+                      System.out.println("Publishing to topic: " + topic);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Added recipes to remove String feature flags.

## What's your motivation?
Give an example of how to cover additional types, based on what's now been demonstrated for boolean and Strings.