### PR TITLE
Remove unused local variables despite potential side effects after removing feature flag

### DIFF
--- a/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
@@ -70,7 +70,7 @@ public class RemoveBooleanFlag extends Recipe {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (methodMatcher.matches(mi) && isFeatureKey(mi.getArguments().get(0))) {
                     doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
-                    doAfterVisit(new RemoveUnusedLocalVariables(null, true).getVisitor());
+                    doAfterVisit(Repeat.repeatUntilStable(new RemoveUnusedLocalVariables(null, true).getVisitor(), 3));
                     doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
                     J.Literal literal = new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, String.valueOf(replacementValue), null, JavaType.Primitive.Boolean);
                     return literal.withPrefix(mi.getPrefix());

--- a/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
@@ -70,7 +70,7 @@ public class RemoveBooleanFlag extends Recipe {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (methodMatcher.matches(mi) && isFeatureKey(mi.getArguments().get(0))) {
                     doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
-                    doAfterVisit(new RemoveUnusedLocalVariables(null, null).getVisitor());
+                    doAfterVisit(new RemoveUnusedLocalVariables(null, true).getVisitor());
                     doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
                     J.Literal literal = new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, String.valueOf(replacementValue), null, JavaType.Primitive.Boolean);
                     return literal.withPrefix(mi.getPrefix());

--- a/src/main/java/org/openrewrite/featureflags/RemoveStringFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveStringFlag.java
@@ -70,7 +70,7 @@ public class RemoveStringFlag extends Recipe {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (methodMatcher.matches(mi) && isFeatureKey(mi.getArguments().get(0))) {
                     doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
-                    doAfterVisit(new RemoveUnusedLocalVariables(null, null).getVisitor());
+                    doAfterVisit(new RemoveUnusedLocalVariables(null, true).getVisitor());
                     doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
                     J.Literal literal = new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, '"' + replacementValue + '"', null, JavaType.Primitive.String);
                     return literal.withPrefix(mi.getPrefix());

--- a/src/main/java/org/openrewrite/featureflags/RemoveStringFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveStringFlag.java
@@ -70,7 +70,7 @@ public class RemoveStringFlag extends Recipe {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (methodMatcher.matches(mi) && isFeatureKey(mi.getArguments().get(0))) {
                     doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
-                    doAfterVisit(new RemoveUnusedLocalVariables(null, true).getVisitor());
+                    doAfterVisit(Repeat.repeatUntilStable(new RemoveUnusedLocalVariables(null, true).getVisitor(), 3));
                     doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
                     J.Literal literal = new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, '"' + replacementValue + '"', null, JavaType.Primitive.String);
                     return literal.withPrefix(mi.getPrefix());

--- a/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveBoolVariationTest.java
+++ b/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveBoolVariationTest.java
@@ -179,6 +179,89 @@ class RemoveBoolVariationTest implements RewriteTest {
     }
 
     @Test
+    void removeUnusedLDContextWithBuilder() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import com.launchdarkly.sdk.*;
+              import com.launchdarkly.sdk.server.*;
+              class Foo {
+                  LDClient client = new LDClient("sdk-key-123abc");
+                  void bar() {
+                      LDContext context = LDContext.builder("context-key-123abc")
+                        .name("Sandy")
+                        .build();
+                      if (client.boolVariation("flag-key-123abc", context, false)) {
+                          // Application code to show the feature
+                          System.out.println("Feature is on");
+                      }
+                      else {
+                        // The code to run if the feature is off
+                          System.out.println("Feature is off");
+                      }
+                  }
+              }
+              """,
+            """
+              import com.launchdarkly.sdk.*;
+              import com.launchdarkly.sdk.server.*;
+              class Foo {
+                  LDClient client = new LDClient("sdk-key-123abc");
+                  void bar() {
+                      // Application code to show the feature
+                      System.out.println("Feature is on");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeUnusedLDContextWithBuilderContext() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import com.launchdarkly.sdk.*;
+              import com.launchdarkly.sdk.server.*;
+              class Foo {
+                  LDClient client = new LDClient("sdk-key-123abc");
+                  void bar() {
+                      LDContext ldContext = LDContext.create("newValue")
+                      LDContext context = LDContext.builderFromContext(ldContext)
+                                .anonymous(false)
+                                .name("name")
+                                .set("email", "email@gmail.com")
+                                .build();
+                      if (client.boolVariation("flag-key-123abc", context, false)) {
+                          // Application code to show the feature
+                          System.out.println("Feature is on");
+                      }
+                      else {
+                        // The code to run if the feature is off
+                          System.out.println("Feature is off");
+                      }
+                  }
+              }
+              """,
+            """
+              import com.launchdarkly.sdk.*;
+              import com.launchdarkly.sdk.server.*;
+              class Foo {
+                  LDClient client = new LDClient("sdk-key-123abc");
+                  void bar() {
+                      // Application code to show the feature
+                      System.out.println("Feature is on");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void enablePermanentlyWithParameters() {
         rewriteRun(
           // language=java

--- a/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveBoolVariationTest.java
+++ b/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveBoolVariationTest.java
@@ -204,7 +204,6 @@ class RemoveBoolVariationTest implements RewriteTest {
               }
               """,
             """
-              import com.launchdarkly.sdk.*;
               import com.launchdarkly.sdk.server.*;
               class Foo {
                   LDClient client = new LDClient("sdk-key-123abc");
@@ -229,7 +228,7 @@ class RemoveBoolVariationTest implements RewriteTest {
               class Foo {
                   LDClient client = new LDClient("sdk-key-123abc");
                   void bar() {
-                      LDContext ldContext = LDContext.create("newValue")
+                      LDContext ldContext = LDContext.create("newValue");
                       LDContext context = LDContext.builderFromContext(ldContext)
                                 .anonymous(false)
                                 .name("name")
@@ -252,6 +251,7 @@ class RemoveBoolVariationTest implements RewriteTest {
               class Foo {
                   LDClient client = new LDClient("sdk-key-123abc");
                   void bar() {
+                      LDContext ldContext = LDContext.create("newValue");
                       // Application code to show the feature
                       System.out.println("Feature is on");
                   }

--- a/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveBoolVariationTest.java
+++ b/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveBoolVariationTest.java
@@ -246,12 +246,10 @@ class RemoveBoolVariationTest implements RewriteTest {
               }
               """,
             """
-              import com.launchdarkly.sdk.*;
               import com.launchdarkly.sdk.server.*;
               class Foo {
                   LDClient client = new LDClient("sdk-key-123abc");
                   void bar() {
-                      LDContext ldContext = LDContext.create("newValue");
                       // Application code to show the feature
                       System.out.println("Feature is on");
                   }


### PR DESCRIPTION
@timtebeek I would like to first fix this one RemoveUnusedLocalVariables does not clean up LDContext when the [assignment might have side effects](https://github.com/openrewrite/rewrite-static-analysis/blob/cba8ef0a14f87056d42e1d7f4d26b0617af4e614/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java#L169-L196), such as when using the builder. Might need a separate recipe that ignores the potential builder side effect.

I'm thinking to approach this as below

1. To update the below recipe to handle the Local variable removal when there is a builder assigned and if the variable is not use in the method? https://github.com/openrewrite/rewrite-static-analysis/blob/cba8ef0a14f87056d42e1d7f4d26b0617af4e614/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java#L37 


Please confirm if it would work or should I create a new recipe to handle below special cases while removing local variable. 

 - with builder assigned
 - if it just used in logging  context.toString()
 - if it is just used in logging as log.info("log the context", context.toString())
 