### PR TITLE
Inline local variables if assigned from feature flag call

### DIFF
--- a/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
@@ -17,11 +17,13 @@ package org.openrewrite.featureflags;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.analysis.constantfold.ConstantFold;
 import org.openrewrite.analysis.util.CursorUtil;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
@@ -66,24 +68,56 @@ public class RemoveBooleanFlag extends Recipe {
         final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, true);
         JavaVisitor<ExecutionContext> visitor = new JavaVisitor<ExecutionContext>() {
             @Override
+            public @Nullable J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                if (multiVariable.getVariables().size() == 1 && matches(multiVariable.getVariables().get(0).getInitializer())) {
+                    // Remove the variable declaration and inline any references to the variable with the literal value
+                    J.Identifier identifierToReplaceWithLiteral = multiVariable.getVariables().get(0).getName();
+                    doAfterVisit(new JavaVisitor<ExecutionContext>() {
+                        @Override
+                        public J visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
+                            if (SemanticallyEqual.areEqual(ident , identifierToReplaceWithLiteral)) {
+                                return buildLiteral().withPrefix(ident.getPrefix());
+                            }
+                            return ident;
+                        }
+                    });
+                    cleanUpAfterReplacements();
+                    return null;
+                }
+                return super.visitVariableDeclarations(multiVariable, ctx);
+            }
+
+            @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-                if (methodMatcher.matches(mi) && isFeatureKey(mi.getArguments().get(0))) {
-                    doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
-                    doAfterVisit(Repeat.repeatUntilStable(new RemoveUnusedLocalVariables(null, true).getVisitor(), 3));
-                    doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
-                    J.Literal literal = new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, String.valueOf(replacementValue), null, JavaType.Primitive.Boolean);
-                    return literal.withPrefix(mi.getPrefix());
+                if (matches(mi)) {
+                    cleanUpAfterReplacements();
+                    return buildLiteral().withPrefix(mi.getPrefix());
                 }
                 return mi;
             }
 
-            private boolean isFeatureKey(Expression firstArgument) {
-                return CursorUtil.findCursorForTree(getCursor(), firstArgument)
-                               .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
-                               .map(featureKey::equals)
-                               .orSome(false);
+            private boolean matches(@Nullable Expression mi) {
+                if (methodMatcher.matches(mi)) {
+                    Expression firstArgument = ((J.MethodInvocation) mi).getArguments().get(0);
+                    return CursorUtil.findCursorForTree(getCursor(), firstArgument)
+                            .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
+                            .map(featureKey::equals)
+                            .orSome(false);
+                }
+                return false;
             }
+
+            private void cleanUpAfterReplacements() {
+                doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
+                doAfterVisit(Repeat.repeatUntilStable(new RemoveUnusedLocalVariables(null, true).getVisitor(), 3));
+                doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
+            }
+
+            private J.Literal buildLiteral() {
+                return new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, String.valueOf(replacementValue), null, JavaType.Primitive.Boolean);
+            }
+
         };
         return Preconditions.check(new UsesMethod<>(methodMatcher), visitor);
     }

--- a/src/test/java/org/openrewrite/featureflags/RemoveBooleanFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/RemoveBooleanFlagTest.java
@@ -34,7 +34,7 @@ class RemoveBooleanFlagTest implements RewriteTest {
           java(
             """
               package com.acme.bank;
-              
+
               public class CustomLaunchDarklyWrapper {
                   public boolean featureFlagEnabled(String key, boolean fallback) {
                       return fallback;
@@ -50,7 +50,8 @@ class RemoveBooleanFlagTest implements RewriteTest {
               class Foo {
                   private CustomLaunchDarklyWrapper wrapper = new CustomLaunchDarklyWrapper();
                   void bar() {
-                      if (wrapper.featureFlagEnabled("flag-key-123abc", false)) {
+                      boolean enabled = wrapper.featureFlagEnabled("flag-key-123abc", false);
+                      if (enabled) {
                           // Application code to show the feature
                           System.out.println("Feature is on");
                       }
@@ -84,7 +85,7 @@ class RemoveBooleanFlagTest implements RewriteTest {
               package com.osd.util;
               import java.util.Map;
               import java.util.HashMap;
-              
+
               public class ToggleChecker {
                   public boolean isToggleEnabled(String toggleName, boolean fallback) {
                       Map<String,Boolean> toggleMap = new HashMap<>();
@@ -134,7 +135,7 @@ class RemoveBooleanFlagTest implements RewriteTest {
           java(
             """
               package com.acme.bank;
-              
+
               public class CustomLaunchDarklyWrapper {
                   public boolean featureFlagEnabled(String key, boolean fallback) {
                       return fallback;
@@ -149,7 +150,7 @@ class RemoveBooleanFlagTest implements RewriteTest {
               import com.acme.bank.CustomLaunchDarklyWrapper;
               class Foo {
                   private static final String FEATURE_TOGGLE = "flag-key-123abc";
-              
+
                   private CustomLaunchDarklyWrapper wrapper = new CustomLaunchDarklyWrapper();
                   void bar() {
                       if (wrapper.featureFlagEnabled(FEATURE_TOGGLE, false)) {
@@ -183,7 +184,7 @@ class RemoveBooleanFlagTest implements RewriteTest {
           java(
             """
               package com.acme.bank;
-              
+
               public class CustomLaunchDarklyWrapper {
                   public boolean featureFlagEnabled(String key, boolean fallback) {
                       return fallback;

--- a/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.featureflags;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
@@ -62,8 +61,7 @@ class RemoveStringFlagTest implements RewriteTest {
             """
               class Foo {
                   void bar() {
-                      String topic = "topic-456";
-                      System.out.println("Publishing to topic: " + topic);
+                      System.out.println("Publishing to topic: " + "topic-456");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveBoolVariationTest.java
+++ b/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveBoolVariationTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.featureflags.launchdarkly;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -77,10 +78,10 @@ class RemoveBoolVariationTest implements RewriteTest {
             """
               import com.launchdarkly.sdk.LDContext;
               import com.launchdarkly.sdk.server.LDClient;
-              
+
               class Foo {
                   private static final String FEATURE_FLAG_123ABC = "flag-key-123abc";
-              
+
                   private LDClient client = new LDClient("sdk-key-123abc");
                   void bar() {
                       LDContext context = null;
@@ -333,6 +334,7 @@ class RemoveBoolVariationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-feature-flags/issues/40")
     @Test
     void localVariablesNotInlined() {
         // language=java
@@ -357,12 +359,8 @@ class RemoveBoolVariationTest implements RewriteTest {
             """
               class Foo {
                   void bar() {
-                      // Local variables not yet inlined
-                      boolean flagEnabled = true;
-                      if (flagEnabled) {
-                          // Application code to show the feature
-                          System.out.println("Feature is on");
-                      }
+                      // Application code to show the feature
+                      System.out.println("Feature is on");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveStringVariationTest.java
+++ b/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveStringVariationTest.java
@@ -54,8 +54,7 @@ class RemoveStringVariationTest implements RewriteTest {
             """
               class Foo {
                   void bar() {
-                      String topic = "topic-456";
-                      System.out.println("Publishing to topic: " + topic);
+                      System.out.println("Publishing to topic: " + "topic-456");
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
Remove single variable declarations & usages if assigned from a matching feature flag API call.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite-feature-flags/issues/40