### PR TITLE
Adapting tests to launchdarkly-java-server-sdk:7.10.1 release

### DIFF
--- a/src/test/java/org/openrewrite/featureflags/launchdarkly/UpgradeLaunchDarkly7Test.java
+++ b/src/test/java/org/openrewrite/featureflags/launchdarkly/UpgradeLaunchDarkly7Test.java
@@ -69,7 +69,7 @@ class UpgradeLaunchDarkly7Test implements RewriteTest {
                   </project>
                   """,
                 spec -> spec.after(actual -> {
-                      Matcher matcher = Pattern.compile("<version>(7\\.\\d\\.\\d+)</version>").matcher(actual);
+                      Matcher matcher = Pattern.compile("<version>(7[.][0-9]+[.][0-9])</version>").matcher(actual);
                       assertTrue(matcher.find(), actual);
                       return """
                         <?xml version="1.0" encoding="UTF-8"?>
@@ -113,7 +113,7 @@ class UpgradeLaunchDarkly7Test implements RewriteTest {
                   }
                   """,
                 spec -> spec.after(actual -> {
-                    Matcher matcher = Pattern.compile("com\\.launchdarkly:launchdarkly-java-server-sdk:(7\\.\\d+\\.\\d+)").matcher(actual);
+                    Matcher matcher = Pattern.compile("com\\.launchdarkly:launchdarkly-java-server-sdk:(7[.][0-9]+[.][0-9])").matcher(actual);
                     assertTrue(matcher.find(), actual);
                     return """
                         plugins {


### PR DESCRIPTION
## What's changed?

Minor change in the test expectations to accommodate for release of 7.10.1 of `launchdarkly-java-server-sdk`.

## What's your motivation?
Fix broken CI:
```
UpgradeLaunchDarkly7Test > Dependencies > mavenDependency() FAILED
    org.opentest4j.AssertionFailedError: <?xml version="1.0" encoding="UTF-8"?>
    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
      <modelVersion>4.0.0</modelVersion>
      <groupId>com.example</groupId>
      <artifactId>demo</artifactId>
      <version>0.0.1-SNAPSHOT</version>
      <dependencies>
        <dependency>
          <groupId>com.launchdarkly</groupId>
          <artifactId>launchdarkly-java-server-sdk</artifactId>
          <version>7.10.1</version>
        </dependency>
      </dependencies>
    </project> ==> expected: <true> but was: <false>
```
