### PR TITLE
Remove unused private methods after removing feature flag

### DIFF
--- a/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
@@ -32,6 +32,7 @@ import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.RemoveUnusedLocalVariables;
 import org.openrewrite.staticanalysis.RemoveUnusedPrivateFields;
+import org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods;
 import org.openrewrite.staticanalysis.SimplifyConstantIfBranchExecution;
 
 @EqualsAndHashCode(callSuper = false)
@@ -112,6 +113,7 @@ public class RemoveBooleanFlag extends Recipe {
                 doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
                 doAfterVisit(Repeat.repeatUntilStable(new RemoveUnusedLocalVariables(null, null, true).getVisitor(), 3));
                 doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
+                doAfterVisit(new RemoveUnusedPrivateMethods().getVisitor());
             }
 
             private J.Literal buildLiteral() {

--- a/src/main/java/org/openrewrite/featureflags/RemoveStringFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveStringFlag.java
@@ -32,6 +32,7 @@ import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.RemoveUnusedLocalVariables;
 import org.openrewrite.staticanalysis.RemoveUnusedPrivateFields;
+import org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods;
 import org.openrewrite.staticanalysis.SimplifyConstantIfBranchExecution;
 
 @EqualsAndHashCode(callSuper = false)
@@ -112,6 +113,7 @@ public class RemoveStringFlag extends Recipe {
                 doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
                 doAfterVisit(Repeat.repeatUntilStable(new RemoveUnusedLocalVariables(null, null, true).getVisitor(), 3));
                 doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
+                doAfterVisit(new RemoveUnusedPrivateMethods().getVisitor());
             }
 
             private J.Literal buildLiteral() {

--- a/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/RemoveStringFlagTest.java
@@ -98,4 +98,44 @@ class RemoveStringFlagTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void removeUnusedPrivateMethodsAfterRemoval() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveStringFlag("com.acme.bank.InHouseFF getStringFeatureFlagValue(String, String)", "flag-key-123abc", "topic-456")),
+          // language=java
+          java(
+            """
+              import com.acme.bank.InHouseFF;
+              class Foo {
+                  private InHouseFF inHouseFF = new InHouseFF();
+                  void bar() {
+                      String topic = inHouseFF.getStringFeatureFlagValue("flag-key-123abc", "topic-123");
+                      if ("topic-456".equals(inHouseFF.getStringFeatureFlagValue("flag-key-123abc", "topic-123"))) {
+                          handleOn();
+                      } else {
+                          handleOff();
+                      }
+                  }
+                  private void handleOn() {
+                      System.out.println("Feature is on");
+                  }
+                  private void handleOff() {
+                      System.out.println("Feature is off");
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      handleOn();
+                  }
+                  private void handleOn() {
+                      System.out.println("Feature is on");
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Similar to removal of unused private fields, to avoid lingering methods.