### PR TITLE
Add recipe to remove OpenFeature String feature flags

### DIFF
--- a/src/main/java/org/openrewrite/featureflags/openfeature/RemoveGetStringValue.java
+++ b/src/main/java/org/openrewrite/featureflags/openfeature/RemoveGetStringValue.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.openfeature;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.featureflags.RemoveStringFlag;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveGetStringValue extends Recipe {
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "topic-456")
+    String replacementValue;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove OpenFeature's `getStringValue` for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `getStringValue()` invocations for `featureKey` with `replacementValue`, and simplify constant if branch execution.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new RemoveStringFlag(
+                "dev.openfeature.sdk.Features getStringValue(String, ..)",
+                featureKey, replacementValue));
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/openfeature/RemoveGetStringValueTest.java
+++ b/src/test/java/org/openrewrite/featureflags/openfeature/RemoveGetStringValueTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.openfeature;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveGetStringValueTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveGetStringValue("flag-key-123abc", "production"))
+          .parser(JavaParser.fromJavaVersion().classpath("sdk"));
+    }
+
+    @DocumentExample
+    @Test
+    void removeGetStringValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      String environment = client.getStringValue("flag-key-123abc", "default");
+                      if ("production".equals(environment)) {
+                          System.out.println("Production mode");
+                      } else {
+                          System.out.println("Default mode");
+                      }
+                  }
+              }
+              """,
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      System.out.println("Production mode");
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Add `RemoveGetStringValue` recipe for OpenFeature that removes string-based feature flags.

## Changes
- Created `RemoveGetStringValue` recipe that:
  - Removes `getStringValue()` invocations for a specific feature key
  - Replaces them with a specified replacement value
  - Simplifies constant if branch execution
  - Delegates to the generic `RemoveStringFlag` recipe
- Added comprehensive test coverage in `RemoveGetStringValueTest`
- Modeled after LaunchDarkly's `RemoveStringVariation` recipe
- Follows the same pattern as existing OpenFeature `RemoveGetBooleanValue`

## Test plan
- [x] Unit tests pass (`RemoveGetStringValueTest`)
- [x] Full build completes successfully
- [x] Recipe properly removes string feature flags and simplifies conditional logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)