### PR TITLE
Add recipe to remove integer feature flags

### DIFF
--- a/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveBooleanFlag.java
@@ -97,9 +97,9 @@ public class RemoveBooleanFlag extends Recipe {
                 return mi;
             }
 
-            private boolean matches(@Nullable Expression mi) {
-                if (methodMatcher.matches(mi)) {
-                    Expression firstArgument = ((J.MethodInvocation) mi).getArguments().get(0);
+            private boolean matches(@Nullable Expression expression) {
+                if (methodMatcher.matches(expression)) {
+                    Expression firstArgument = ((J.MethodInvocation) expression).getArguments().get(0);
                     return CursorUtil.findCursorForTree(getCursor(), firstArgument)
                             .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
                             .map(featureKey::equals)
@@ -117,7 +117,6 @@ public class RemoveBooleanFlag extends Recipe {
             private J.Literal buildLiteral() {
                 return new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, String.valueOf(replacementValue), null, JavaType.Primitive.Boolean);
             }
-
         };
         return Preconditions.check(new UsesMethod<>(methodMatcher), visitor);
     }

--- a/src/main/java/org/openrewrite/featureflags/RemoveIntegerFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveIntegerFlag.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.analysis.constantfold.ConstantFold;
+import org.openrewrite.analysis.util.CursorUtil;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.SemanticallyEqual;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.staticanalysis.RemoveUnusedLocalVariables;
+import org.openrewrite.staticanalysis.RemoveUnusedPrivateFields;
+import org.openrewrite.staticanalysis.SimplifyConstantIfBranchExecution;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveIntegerFlag extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove an integer feature flag for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace method invocations for feature key with value, and simplify constant if branch execution.";
+    }
+
+    @Option(displayName = "Method pattern",
+            description = "A method pattern to match against. The first argument must be the feature key as `String`.",
+            example = "dev.openfeature.sdk.Client getIntegerValue(String, Integer)")
+    String methodPattern;
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "42")
+    Integer replacementValue;
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, true);
+        JavaVisitor<ExecutionContext> visitor = new JavaVisitor<ExecutionContext>() {
+            @Override
+            public @Nullable J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                if (multiVariable.getVariables().size() == 1 && matches(multiVariable.getVariables().get(0).getInitializer())) {
+                    // Remove the variable declaration and inline any references to the variable with the literal value
+                    J.Identifier identifierToReplaceWithLiteral = multiVariable.getVariables().get(0).getName();
+                    doAfterVisit(new JavaVisitor<ExecutionContext>() {
+                        @Override
+                        public J visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
+                            if (SemanticallyEqual.areEqual(ident , identifierToReplaceWithLiteral)) {
+                                return buildLiteral().withPrefix(ident.getPrefix());
+                            }
+                            return ident;
+                        }
+                    });
+                    cleanUpAfterReplacements();
+                    return null;
+                }
+                return super.visitVariableDeclarations(multiVariable, ctx);
+            }
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                if (matches(mi)) {
+                    cleanUpAfterReplacements();
+                    return buildLiteral().withPrefix(mi.getPrefix());
+                }
+                return mi;
+            }
+
+            private boolean matches(@Nullable Expression expression) {
+                if (methodMatcher.matches(expression)) {
+                    Expression firstArgument = ((J.MethodInvocation) expression).getArguments().get(0);
+                    return CursorUtil.findCursorForTree(getCursor(), firstArgument)
+                            .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
+                            .map(featureKey::equals)
+                            .orSome(false);
+                }
+                return false;
+            }
+
+            private void cleanUpAfterReplacements() {
+                doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
+                doAfterVisit(Repeat.repeatUntilStable(new RemoveUnusedLocalVariables(null, null, true).getVisitor(), 3));
+                doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
+            }
+
+            private J.Literal buildLiteral() {
+                return new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, String.valueOf(replacementValue), null, JavaType.Primitive.Int);
+            }
+        };
+        return Preconditions.check(new UsesMethod<>(methodMatcher), visitor);
+    }
+}

--- a/src/main/java/org/openrewrite/featureflags/launchdarkly/RemoveIntVariation.java
+++ b/src/main/java/org/openrewrite/featureflags/launchdarkly/RemoveIntVariation.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.launchdarkly;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.featureflags.RemoveIntegerFlag;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveIntVariation extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove LaunchDarkly's `intVariation` for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `intVariation` invocations for feature key with value, and simplify constant if branch execution.";
+    }
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "42")
+    Integer replacementValue;
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new RemoveIntegerFlag(
+                "com.launchdarkly.sdk.server.LDClient intVariation(String, com.launchdarkly.sdk.*, int)",
+                featureKey, replacementValue));
+    }
+}

--- a/src/main/java/org/openrewrite/featureflags/openfeature/RemoveGetIntegerValue.java
+++ b/src/main/java/org/openrewrite/featureflags/openfeature/RemoveGetIntegerValue.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.openfeature;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.featureflags.RemoveIntegerFlag;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveGetIntegerValue extends Recipe {
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "42")
+    Integer replacementValue;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove OpenFeature's `getIntegerValue` for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `getIntegerValue()` invocations for `featureKey` with `replacementValue`, and simplify constant if branch execution.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new RemoveIntegerFlag(
+                "dev.openfeature.sdk.Features getIntegerValue(String, ..)",
+                featureKey, replacementValue));
+    }
+}

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -56,6 +56,32 @@ examples:
     language: java
 ---
 type: specs.openrewrite.org/v1beta/example
+recipeName: org.openrewrite.featureflags.RemoveIntegerFlag
+examples:
+- description: '`RemoveIntegerFlagTest#removeIntegerFeatureFlag`'
+  parameters:
+  - com.acme.bank.InHouseFF getIntegerFeatureFlagValue(String, Integer)
+  - flag-key-123abc
+  - '42'
+  sources:
+  - before: |
+      import com.acme.bank.InHouseFF;
+      class Foo {
+          private InHouseFF inHouseFF = new InHouseFF();
+          void bar() {
+              Integer maxRetries = inHouseFF.getIntegerFeatureFlagValue("flag-key-123abc", 3);
+              System.out.println("Max retries: " + maxRetries);
+          }
+      }
+    after: |
+      class Foo {
+          void bar() {
+              System.out.println("Max retries: " + 42);
+          }
+      }
+    language: java
+---
+type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.featureflags.RemoveStringFlag
 examples:
 - description: '`RemoveStringFlagTest#removeStringFeatureFlag`'
@@ -211,6 +237,33 @@ examples:
     language: java
 ---
 type: specs.openrewrite.org/v1beta/example
+recipeName: org.openrewrite.featureflags.launchdarkly.RemoveIntVariation
+examples:
+- description: '`RemoveIntVariationTest#replaceIntVariation`'
+  parameters:
+  - flag-key-123abc
+  - '100'
+  sources:
+  - before: |
+      import com.launchdarkly.sdk.LDContext;
+      import com.launchdarkly.sdk.server.LDClient;
+      class Foo {
+          private LDClient client = new LDClient("sdk-key-123abc");
+          void bar() {
+              LDContext context = null;
+              int maxRetries = client.intVariation("flag-key-123abc", context, 3);
+              System.out.println("Max retries: " + maxRetries);
+          }
+      }
+    after: |
+      class Foo {
+          void bar() {
+              System.out.println("Max retries: " + 100);
+          }
+      }
+    language: java
+---
+type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.featureflags.launchdarkly.RemoveStringVariation
 examples:
 - description: '`RemoveStringVariationTest#replaceStringVariation`'
@@ -349,6 +402,33 @@ examples:
       class Foo {
           void bar(Client client) {
               System.out.println("Feature enabled");
+          }
+      }
+    language: java
+---
+type: specs.openrewrite.org/v1beta/example
+recipeName: org.openrewrite.featureflags.openfeature.RemoveGetIntegerValue
+examples:
+- description: '`RemoveGetIntegerValueTest#removeGetIntegerValue`'
+  parameters:
+  - flag-key-123abc
+  - '100'
+  sources:
+  - before: |
+      import dev.openfeature.sdk.Client;
+
+      class Foo {
+          void bar(Client client) {
+              Integer maxRetries = client.getIntegerValue("flag-key-123abc", 3);
+              System.out.println("Max retries: " + maxRetries);
+          }
+      }
+    after: |
+      import dev.openfeature.sdk.Client;
+
+      class Foo {
+          void bar(Client client) {
+              System.out.println("Max retries: " + 100);
           }
       }
     language: java

--- a/src/test/java/org/openrewrite/featureflags/RemoveIntegerFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/RemoveIntegerFlagTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveIntegerFlagTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveIntegerFlag("com.acme.bank.InHouseFF getIntegerFeatureFlagValue(String, Integer)", "flag-key-123abc", 42))
+          // language=java
+          .parser(JavaParser.fromJavaVersion().dependsOn(
+            """
+              package com.acme.bank;
+              public class InHouseFF {
+                  public Integer getIntegerFeatureFlagValue(String key, Integer fallback) {
+                      return fallback;
+                  }
+              }
+              """
+          ));
+    }
+
+    @DocumentExample
+    @Test
+    void removeIntegerFeatureFlag() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveIntegerFlag("com.acme.bank.InHouseFF getIntegerFeatureFlagValue(String, Integer)", "flag-key-123abc", 42)),
+          // language=java
+          java(
+            """
+              import com.acme.bank.InHouseFF;
+              class Foo {
+                  private InHouseFF inHouseFF = new InHouseFF();
+                  void bar() {
+                      Integer maxRetries = inHouseFF.getIntegerFeatureFlagValue("flag-key-123abc", 3);
+                      System.out.println("Max retries: " + maxRetries);
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Max retries: " + 42);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeVariableDeclarationWithIntegerFlag() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveIntegerFlag("com.acme.bank.InHouseFF getIntegerFeatureFlagValue(String, Integer)", "flag-key-123abc", 100)),
+          // language=java
+          java(
+            """
+              import com.acme.bank.InHouseFF;
+              class Foo {
+                  private InHouseFF inHouseFF = new InHouseFF();
+                  void bar() {
+                      int threshold = inHouseFF.getIntegerFeatureFlagValue("flag-key-123abc", 50);
+                      System.out.println("Threshold: " + threshold);
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Threshold: " + 100);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeInlineIntegerUsage() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveIntegerFlag("com.acme.bank.InHouseFF getIntegerFeatureFlagValue(String, Integer)", "flag-key-123abc", 5)),
+          // language=java
+          java(
+            """
+              import com.acme.bank.InHouseFF;
+              class Foo {
+                  private InHouseFF inHouseFF = new InHouseFF();
+                  void bar() {
+                      System.out.println("Max retries: " + inHouseFF.getIntegerFeatureFlagValue("flag-key-123abc", 10));
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Max retries: " + 5);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveIntVariationTest.java
+++ b/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveIntVariationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.launchdarkly;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveIntVariationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveIntVariation("flag-key-123abc", 100))
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "launchdarkly-java-server-sdk-6.+"));
+    }
+
+    @DocumentExample
+    @Test
+    void replaceIntVariation() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import com.launchdarkly.sdk.LDContext;
+              import com.launchdarkly.sdk.server.LDClient;
+              class Foo {
+                  private LDClient client = new LDClient("sdk-key-123abc");
+                  void bar() {
+                      LDContext context = null;
+                      int maxRetries = client.intVariation("flag-key-123abc", context, 3);
+                      System.out.println("Max retries: " + maxRetries);
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Max retries: " + 100);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceIntVariationInline() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import com.launchdarkly.sdk.LDContext;
+              import com.launchdarkly.sdk.server.LDClient;
+              class Foo {
+                  private LDClient client = new LDClient("sdk-key-123abc");
+                  void bar() {
+                      LDContext context = null;
+                      System.out.println("Timeout: " + client.intVariation("flag-key-123abc", context, 30));
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Timeout: " + 100);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/openfeature/RemoveGetIntegerValueTest.java
+++ b/src/test/java/org/openrewrite/featureflags/openfeature/RemoveGetIntegerValueTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.openfeature;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveGetIntegerValueTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveGetIntegerValue("flag-key-123abc", 100))
+          .parser(JavaParser.fromJavaVersion().classpath("sdk"));
+    }
+
+    @DocumentExample
+    @Test
+    void removeGetIntegerValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      Integer maxRetries = client.getIntegerValue("flag-key-123abc", 3);
+                      System.out.println("Max retries: " + maxRetries);
+                  }
+              }
+              """,
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      System.out.println("Max retries: " + 100);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeInlineIntegerValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      System.out.println("Timeout: " + client.getIntegerValue("flag-key-123abc", 30));
+                  }
+              }
+              """,
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      System.out.println("Timeout: " + 100);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeWithPrimitiveType() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      int threshold = client.getIntegerValue("flag-key-123abc", 50);
+                      System.out.println("Threshold: " + threshold);
+                  }
+              }
+              """,
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      System.out.println("Threshold: " + 100);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Add `RemoveIntegerFlag` recipe for removing integer-valued feature flags.

## Changes
- Created `RemoveIntegerFlag` recipe that:
  - Removes integer feature flag method invocations for a specific feature key
  - Replaces them with a specified integer replacement value
  - Inlines variable declarations and simplifies constant expressions
  - Provides a generic solution accepting a method pattern parameter
- Added comprehensive test coverage in `RemoveIntegerFlagTest`
- Follows the same pattern as existing `RemoveBooleanFlag` and `RemoveStringFlag` recipes

## Test plan
- [x] Unit tests pass (3 test cases covering different scenarios)
- [x] Full build completes successfully
- [x] Recipe properly removes integer feature flags and inlines values
- [x] Variable declarations are removed and references are replaced with literals

## Implementation Details
The recipe uses `JavaType.Primitive.Int` for literal type and implements the same visitor pattern as the boolean and string flag recipes, ensuring consistency across the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)