### PR TITLE
Add recipes to remove double feature flags

### DIFF
--- a/src/main/java/org/openrewrite/featureflags/RemoveDoubleFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/RemoveDoubleFlag.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.analysis.constantfold.ConstantFold;
+import org.openrewrite.analysis.util.CursorUtil;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.SemanticallyEqual;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.staticanalysis.RemoveUnusedLocalVariables;
+import org.openrewrite.staticanalysis.RemoveUnusedPrivateFields;
+import org.openrewrite.staticanalysis.SimplifyConstantIfBranchExecution;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveDoubleFlag extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove a double feature flag for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace method invocations for feature key with value, and simplify constant if branch execution.";
+    }
+
+    @Option(displayName = "Method pattern",
+            description = "A method pattern to match against. The first argument must be the feature key as `String`.",
+            example = "dev.openfeature.sdk.Client getDoubleValue(String, Double)")
+    String methodPattern;
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "3.14")
+    Double replacementValue;
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, true);
+        JavaVisitor<ExecutionContext> visitor = new JavaVisitor<ExecutionContext>() {
+            @Override
+            public @Nullable J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                if (multiVariable.getVariables().size() == 1 && matches(multiVariable.getVariables().get(0).getInitializer())) {
+                    // Remove the variable declaration and inline any references to the variable with the literal value
+                    J.Identifier identifierToReplaceWithLiteral = multiVariable.getVariables().get(0).getName();
+                    doAfterVisit(new JavaVisitor<ExecutionContext>() {
+                        @Override
+                        public J visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
+                            if (SemanticallyEqual.areEqual(ident , identifierToReplaceWithLiteral)) {
+                                return buildLiteral().withPrefix(ident.getPrefix());
+                            }
+                            return ident;
+                        }
+                    });
+                    cleanUpAfterReplacements();
+                    return null;
+                }
+                return super.visitVariableDeclarations(multiVariable, ctx);
+            }
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                if (matches(mi)) {
+                    cleanUpAfterReplacements();
+                    return buildLiteral().withPrefix(mi.getPrefix());
+                }
+                return mi;
+            }
+
+            private boolean matches(@Nullable Expression expression) {
+                if (methodMatcher.matches(expression)) {
+                    Expression firstArgument = ((J.MethodInvocation) expression).getArguments().get(0);
+                    return CursorUtil.findCursorForTree(getCursor(), firstArgument)
+                            .bind(c -> ConstantFold.findConstantLiteralValue(c, String.class))
+                            .map(featureKey::equals)
+                            .orSome(false);
+                }
+                return false;
+            }
+
+            private void cleanUpAfterReplacements() {
+                doAfterVisit(new SimplifyConstantIfBranchExecution().getVisitor());
+                doAfterVisit(Repeat.repeatUntilStable(new RemoveUnusedLocalVariables(null, null, true).getVisitor(), 3));
+                doAfterVisit(new RemoveUnusedPrivateFields().getVisitor());
+            }
+
+            private J.Literal buildLiteral() {
+                return new J.Literal(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, replacementValue, String.valueOf(replacementValue), null, JavaType.Primitive.Double);
+            }
+        };
+        return Preconditions.check(new UsesMethod<>(methodMatcher), visitor);
+    }
+}

--- a/src/main/java/org/openrewrite/featureflags/launchdarkly/RemoveDoubleVariation.java
+++ b/src/main/java/org/openrewrite/featureflags/launchdarkly/RemoveDoubleVariation.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.launchdarkly;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.featureflags.RemoveDoubleFlag;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveDoubleVariation extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove LaunchDarkly's `doubleVariation` for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `doubleVariation` invocations for feature key with value, and simplify constant if branch execution.";
+    }
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "3.14")
+    Double replacementValue;
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new RemoveDoubleFlag(
+                "com.launchdarkly.sdk.server.LDClient doubleVariation(String, com.launchdarkly.sdk.*, double)",
+                featureKey, replacementValue));
+    }
+}

--- a/src/main/java/org/openrewrite/featureflags/openfeature/RemoveGetDoubleValue.java
+++ b/src/main/java/org/openrewrite/featureflags/openfeature/RemoveGetDoubleValue.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.openfeature;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.featureflags.RemoveDoubleFlag;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveGetDoubleValue extends Recipe {
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "3.14")
+    Double replacementValue;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove OpenFeature's `getDoubleValue` for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `getDoubleValue()` invocations for `featureKey` with `replacementValue`, and simplify constant if branch execution.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new RemoveDoubleFlag(
+                "dev.openfeature.sdk.Features getDoubleValue(String, ..)",
+                featureKey, replacementValue));
+    }
+}

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -82,6 +82,32 @@ examples:
     language: java
 ---
 type: specs.openrewrite.org/v1beta/example
+recipeName: org.openrewrite.featureflags.RemoveDoubleFlag
+examples:
+- description: '`RemoveDoubleFlagTest#removeDoubleFeatureFlag`'
+  parameters:
+  - com.acme.bank.InHouseFF getDoubleFeatureFlagValue(String, Double)
+  - flag-key-123abc
+  - '3.14'
+  sources:
+  - before: |
+      import com.acme.bank.InHouseFF;
+      class Foo {
+          private InHouseFF inHouseFF = new InHouseFF();
+          void bar() {
+              Double multiplier = inHouseFF.getDoubleFeatureFlagValue("flag-key-123abc", 1.5);
+              System.out.println("Multiplier: " + multiplier);
+          }
+      }
+    after: |
+      class Foo {
+          void bar() {
+              System.out.println("Multiplier: " + 3.14);
+          }
+      }
+    language: java
+---
+type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.featureflags.RemoveStringFlag
 examples:
 - description: '`RemoveStringFlagTest#removeStringFeatureFlag`'
@@ -264,6 +290,33 @@ examples:
     language: java
 ---
 type: specs.openrewrite.org/v1beta/example
+recipeName: org.openrewrite.featureflags.launchdarkly.RemoveDoubleVariation
+examples:
+- description: '`RemoveDoubleVariationTest#replaceDoubleVariation`'
+  parameters:
+  - flag-key-123abc
+  - '3.14'
+  sources:
+  - before: |
+      import com.launchdarkly.sdk.LDContext;
+      import com.launchdarkly.sdk.server.LDClient;
+      class Foo {
+          private LDClient client = new LDClient("sdk-key-123abc");
+          void bar() {
+              LDContext context = null;
+              double multiplier = client.doubleVariation("flag-key-123abc", context, 1.5);
+              System.out.println("Multiplier: " + multiplier);
+          }
+      }
+    after: |
+      class Foo {
+          void bar() {
+              System.out.println("Multiplier: " + 3.14);
+          }
+      }
+    language: java
+---
+type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.featureflags.launchdarkly.RemoveStringVariation
 examples:
 - description: '`RemoveStringVariationTest#replaceStringVariation`'
@@ -429,6 +482,33 @@ examples:
       class Foo {
           void bar(Client client) {
               System.out.println("Max retries: " + 100);
+          }
+      }
+    language: java
+---
+type: specs.openrewrite.org/v1beta/example
+recipeName: org.openrewrite.featureflags.openfeature.RemoveGetDoubleValue
+examples:
+- description: '`RemoveGetDoubleValueTest#removeGetDoubleValue`'
+  parameters:
+  - flag-key-123abc
+  - '3.14'
+  sources:
+  - before: |
+      import dev.openfeature.sdk.Client;
+
+      class Foo {
+          void bar(Client client) {
+              Double multiplier = client.getDoubleValue("flag-key-123abc", 1.5);
+              System.out.println("Multiplier: " + multiplier);
+          }
+      }
+    after: |
+      import dev.openfeature.sdk.Client;
+
+      class Foo {
+          void bar(Client client) {
+              System.out.println("Multiplier: " + 3.14);
           }
       }
     language: java

--- a/src/test/java/org/openrewrite/featureflags/RemoveDoubleFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/RemoveDoubleFlagTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveDoubleFlagTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveDoubleFlag("com.acme.bank.InHouseFF getDoubleFeatureFlagValue(String, Double)", "flag-key-123abc", 3.14))
+          // language=java
+          .parser(JavaParser.fromJavaVersion().dependsOn(
+            """
+              package com.acme.bank;
+              public class InHouseFF {
+                  public Double getDoubleFeatureFlagValue(String key, Double fallback) {
+                      return fallback;
+                  }
+              }
+              """
+          ));
+    }
+
+    @DocumentExample
+    @Test
+    void removeDoubleFeatureFlag() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveDoubleFlag("com.acme.bank.InHouseFF getDoubleFeatureFlagValue(String, Double)", "flag-key-123abc", 3.14)),
+          // language=java
+          java(
+            """
+              import com.acme.bank.InHouseFF;
+              class Foo {
+                  private InHouseFF inHouseFF = new InHouseFF();
+                  void bar() {
+                      Double multiplier = inHouseFF.getDoubleFeatureFlagValue("flag-key-123abc", 1.5);
+                      System.out.println("Multiplier: " + multiplier);
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Multiplier: " + 3.14);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeVariableDeclarationWithDoubleFlag() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveDoubleFlag("com.acme.bank.InHouseFF getDoubleFeatureFlagValue(String, Double)", "flag-key-123abc", 2.5)),
+          // language=java
+          java(
+            """
+              import com.acme.bank.InHouseFF;
+              class Foo {
+                  private InHouseFF inHouseFF = new InHouseFF();
+                  void bar() {
+                      double threshold = inHouseFF.getDoubleFeatureFlagValue("flag-key-123abc", 1.0);
+                      System.out.println("Threshold: " + threshold);
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Threshold: " + 2.5);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeInlineDoubleUsage() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveDoubleFlag("com.acme.bank.InHouseFF getDoubleFeatureFlagValue(String, Double)", "flag-key-123abc", 0.75)),
+          // language=java
+          java(
+            """
+              import com.acme.bank.InHouseFF;
+              class Foo {
+                  private InHouseFF inHouseFF = new InHouseFF();
+                  void bar() {
+                      System.out.println("Rate: " + inHouseFF.getDoubleFeatureFlagValue("flag-key-123abc", 0.5));
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Rate: " + 0.75);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveDoubleVariationTest.java
+++ b/src/test/java/org/openrewrite/featureflags/launchdarkly/RemoveDoubleVariationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.launchdarkly;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveDoubleVariationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveDoubleVariation("flag-key-123abc", 3.14))
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "launchdarkly-java-server-sdk-6.+"));
+    }
+
+    @DocumentExample
+    @Test
+    void replaceDoubleVariation() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import com.launchdarkly.sdk.LDContext;
+              import com.launchdarkly.sdk.server.LDClient;
+              class Foo {
+                  private LDClient client = new LDClient("sdk-key-123abc");
+                  void bar() {
+                      LDContext context = null;
+                      double multiplier = client.doubleVariation("flag-key-123abc", context, 1.5);
+                      System.out.println("Multiplier: " + multiplier);
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Multiplier: " + 3.14);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceDoubleVariationInline() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import com.launchdarkly.sdk.LDContext;
+              import com.launchdarkly.sdk.server.LDClient;
+              class Foo {
+                  private LDClient client = new LDClient("sdk-key-123abc");
+                  void bar() {
+                      LDContext context = null;
+                      System.out.println("Rate: " + client.doubleVariation("flag-key-123abc", context, 0.5));
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  void bar() {
+                      System.out.println("Rate: " + 3.14);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/openfeature/RemoveGetDoubleValueTest.java
+++ b/src/test/java/org/openrewrite/featureflags/openfeature/RemoveGetDoubleValueTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.openfeature;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveGetDoubleValueTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveGetDoubleValue("flag-key-123abc", 3.14))
+          .parser(JavaParser.fromJavaVersion().classpath("sdk"));
+    }
+
+    @DocumentExample
+    @Test
+    void removeGetDoubleValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      Double multiplier = client.getDoubleValue("flag-key-123abc", 1.5);
+                      System.out.println("Multiplier: " + multiplier);
+                  }
+              }
+              """,
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      System.out.println("Multiplier: " + 3.14);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeInlineDoubleValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      System.out.println("Rate: " + client.getDoubleValue("flag-key-123abc", 0.5));
+                  }
+              }
+              """,
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      System.out.println("Rate: " + 3.14);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeWithPrimitiveType() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      double threshold = client.getDoubleValue("flag-key-123abc", 1.0);
+                      System.out.println("Threshold: " + threshold);
+                  }
+              }
+              """,
+            """
+              import dev.openfeature.sdk.Client;
+
+              class Foo {
+                  void bar(Client client) {
+                      System.out.println("Threshold: " + 3.14);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for removing feature flag calls that return double values across three frameworks:
- **org.openrewrite.featureflags** (core generic recipe)
- **LaunchDarkly** (`doubleVariation` method)
- **OpenFeature** (`getDoubleValue` method)

## Changes

### New Recipe Classes
- `RemoveDoubleFlag` - Core generic recipe for removing double feature flags
- `RemoveDoubleVariation` - LaunchDarkly-specific wrapper for `doubleVariation()` method  
- `RemoveGetDoubleValue` - OpenFeature-specific wrapper for `getDoubleValue()` method

### Test Coverage
All three recipes include comprehensive test coverage:
- `RemoveDoubleFlagTest` - 3 test cases covering variable declarations, inline usage, and primitive types
- `RemoveDoubleVariationTest` - 2 test cases for LaunchDarkly integration
- `RemoveGetDoubleValueTest` - 3 test cases for OpenFeature integration

### Documentation
- Updated `examples.yml` with example transformations showing before/after code snippets for all three recipes

## Implementation Details

All recipes follow the established pattern from `RemoveIntegerFlag` and support:
- ✅ Variable declaration removal with automatic inlining of references
- ✅ Inline replacement of method calls
- ✅ Both primitive `double` and boxed `Double` types
- ✅ Automatic cleanup of unused variables and dead code
- ✅ Constant if-branch simplification

## Example Transformation

**Before:**
```java
import dev.openfeature.sdk.Client;

class Foo {
    void bar(Client client) {
        Double multiplier = client.getDoubleValue("flag-key-123abc", 1.5);
        System.out.println("Multiplier: " + multiplier);
    }
}
```

**After:**
```java
import dev.openfeature.sdk.Client;

class Foo {
    void bar(Client client) {
        System.out.println("Multiplier: " + 3.14);
    }
}
```

## Test Plan

- [x] All new tests pass
- [x] All existing tests continue to pass
- [x] Follows the same pattern as existing integer/string/boolean flag recipes
- [x] YAML documentation examples added

🤖 Generated with [Claude Code](https://claude.com/claude-code)