### PR TITLE
Add Quarkus feature flags support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     testImplementation("dev.openfeature:sdk:latest.release")
     testImplementation("io.getunleash:unleash-client-java:latest.release")
+    testImplementation("io.quarkiverse.flags:quarkus-flags:latest.release")
     testImplementation("org.ff4j:ff4j-core:2.0.0") // 2.1.x requires Java 21
 
     testRuntimeOnly("com.launchdarkly:launchdarkly-java-server-sdk:5.+")

--- a/src/main/java/org/openrewrite/featureflags/quarkus/RemoveGetInt.java
+++ b/src/main/java/org/openrewrite/featureflags/quarkus/RemoveGetInt.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.quarkus;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.featureflags.RemoveIntegerFlag;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveGetInt extends Recipe {
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "42")
+    Integer replacementValue;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove Quarkus feature flag's `getInt` for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `getInt()` invocations for `featureKey` with `replacementValue`, and simplify constant if branch execution.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new RemoveIntegerFlag(
+                "io.quarkiverse.flags.Flags getInt(String)",
+                featureKey, replacementValue));
+    }
+}

--- a/src/main/java/org/openrewrite/featureflags/quarkus/RemoveGetString.java
+++ b/src/main/java/org/openrewrite/featureflags/quarkus/RemoveGetString.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.quarkus;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.featureflags.RemoveStringFlag;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveGetString extends Recipe {
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "topic-456")
+    String replacementValue;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove Quarkus feature flag's `getString` for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `getString()` invocations for `featureKey` with `replacementValue`, and simplify constant if branch execution.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new RemoveStringFlag(
+                "io.quarkiverse.flags.Flags getString(String)",
+                featureKey, replacementValue));
+    }
+}

--- a/src/main/java/org/openrewrite/featureflags/quarkus/RemoveIsEnabled.java
+++ b/src/main/java/org/openrewrite/featureflags/quarkus/RemoveIsEnabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/featureflags/quarkus/RemoveIsEnabled.java
+++ b/src/main/java/org/openrewrite/featureflags/quarkus/RemoveIsEnabled.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.quarkus;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.featureflags.RemoveBooleanFlag;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class RemoveIsEnabled extends Recipe {
+
+    @Option(displayName = "Feature flag key",
+            description = "The key of the feature flag to remove.",
+            example = "flag-key-123abc")
+    String featureKey;
+
+    @Option(displayName = "Replacement value",
+            description = "The value to replace the feature flag check with.",
+            example = "true")
+    Boolean replacementValue;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove Quarkus feature flag's `isEnabled` for feature key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `isEnabled()` invocations for `featureKey` with `replacementValue`, and simplify constant if branch execution.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new RemoveBooleanFlag(
+                "io.quarkiverse.flags.Flags isEnabled(String)",
+                featureKey, replacementValue));
+    }
+}

--- a/src/main/java/org/openrewrite/featureflags/quarkus/package-info.java
+++ b/src/main/java/org/openrewrite/featureflags/quarkus/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+@NonNullFields
+package org.openrewrite.featureflags.quarkus;
+
+import org.jspecify.annotations.NullMarked;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlag.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.quarkus.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class FindFeatureFlag extends Recipe {
+
+    @Option(displayName = "Feature key",
+            description = "The unique key for the feature flag.",
+            example = "flag-key-123abc",
+            required = false)
+    @Nullable
+    String featureKey;
+
+    @Override
+    public String getDisplayName() {
+        return "Find a Quarkus feature flag";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Find a Quarkus feature flag.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return singletonList(new org.openrewrite.featureflags.search.FindFeatureFlag(
+                "io.quarkiverse.flags.Flags isEnabled(String)", featureKey));
+    }
+}

--- a/src/main/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlag.java
+++ b/src/main/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,8 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 
+import java.util.Arrays;
 import java.util.List;
-
-import static java.util.Collections.singletonList;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -48,7 +47,16 @@ public class FindFeatureFlag extends Recipe {
 
     @Override
     public List<Recipe> getRecipeList() {
-        return singletonList(new org.openrewrite.featureflags.search.FindFeatureFlag(
-                "io.quarkiverse.flags.Flags isEnabled(String)", featureKey));
+        return Arrays.asList(
+                new org.openrewrite.featureflags.search.FindFeatureFlag(
+                        "io.quarkiverse.flags.Flags find(String)", featureKey),
+                new org.openrewrite.featureflags.search.FindFeatureFlag(
+                        "io.quarkiverse.flags.Flags findAndAwait(String)", featureKey),
+                new org.openrewrite.featureflags.search.FindFeatureFlag(
+                        "io.quarkiverse.flags.Flags isEnabled(String)", featureKey),
+                new org.openrewrite.featureflags.search.FindFeatureFlag(
+                        "io.quarkiverse.flags.Flags getString(String)", featureKey),
+                new org.openrewrite.featureflags.search.FindFeatureFlag(
+                        "io.quarkiverse.flags.Flags getInt(String)", featureKey));
     }
 }

--- a/src/main/java/org/openrewrite/featureflags/quarkus/search/package-info.java
+++ b/src/main/java/org/openrewrite/featureflags/quarkus/search/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+@NonNullFields
+package org.openrewrite.featureflags.quarkus.search;
+
+import org.jspecify.annotations.NullMarked;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/test/java/org/openrewrite/featureflags/quarkus/RemoveGetIntTest.java
+++ b/src/test/java/org/openrewrite/featureflags/quarkus/RemoveGetIntTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.quarkus;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveGetIntTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveGetInt("flag-key-123abc", 100))
+          .parser(JavaParser.fromJavaVersion().classpath("quarkus-flags"));
+    }
+
+    @DocumentExample
+    @Test
+    void removeGetInt() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Foo {
+                  void bar(Flags flags) {
+                      int maxRetries = flags.getInt("flag-key-123abc");
+                      System.out.println("Max retries: " + maxRetries);
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Foo {
+                  void bar(Flags flags) {
+                      System.out.println("Max retries: " + 100);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeInlineIntValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Foo {
+                  void bar(Flags flags) {
+                      System.out.println("Timeout: " + flags.getInt("flag-key-123abc"));
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Foo {
+                  void bar(Flags flags) {
+                      System.out.println("Timeout: " + 100);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/quarkus/RemoveGetStringTest.java
+++ b/src/test/java/org/openrewrite/featureflags/quarkus/RemoveGetStringTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.quarkus;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveGetStringTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveGetString("flag-key-123abc", "production"))
+          .parser(JavaParser.fromJavaVersion().classpath("quarkus-flags"));
+    }
+
+    @DocumentExample
+    @Test
+    void removeGetString() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Foo {
+                  void bar(Flags flags) {
+                      String environment = flags.getString("flag-key-123abc");
+                      if ("production".equals(environment)) {
+                          System.out.println("Production mode");
+                      } else {
+                          System.out.println("Default mode");
+                      }
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Foo {
+                  void bar(Flags flags) {
+                      System.out.println("Production mode");
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/quarkus/RemoveIsEnabledTest.java
+++ b/src/test/java/org/openrewrite/featureflags/quarkus/RemoveIsEnabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/featureflags/quarkus/RemoveIsEnabledTest.java
+++ b/src/test/java/org/openrewrite/featureflags/quarkus/RemoveIsEnabledTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.quarkus;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveIsEnabledTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveIsEnabled("flag-key-123abc", true))
+          .parser(JavaParser.fromJavaVersion().classpath("quarkus-flags"));
+    }
+
+    @DocumentExample
+    @Test
+    void removeIsEnabled() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  void bar(Flags flags) {
+                      if (flags.isEnabled("flag-key-123abc")) {
+                          System.out.println("Feature enabled");
+                      } else {
+                          System.out.println("Feature disabled");
+                      }
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  void bar(Flags flags) {
+                      System.out.println("Feature enabled");
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlagTest.java
@@ -171,4 +171,96 @@ class FindFeatureFlagTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void findGetStringFlag() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFeatureFlag(null)),
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      String environment = flags.getString("env-flag");
+                      System.out.println(environment);
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      String environment = /*~~>*/flags.getString("env-flag");
+                      System.out.println(environment);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findGetIntFlag() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFeatureFlag(null)),
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      int maxRetries = flags.getInt("max-retries");
+                      System.out.println(maxRetries);
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      int maxRetries = /*~~>*/flags.getInt("max-retries");
+                      System.out.println(maxRetries);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findAllFlagTypes() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFeatureFlag(null)),
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      boolean enabled = flags.isEnabled("feature-enabled");
+                      String env = flags.getString("environment");
+                      int retries = flags.getInt("max-retries");
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      boolean enabled = /*~~>*/flags.isEnabled("feature-enabled");
+                      String env = /*~~>*/flags.getString("environment");
+                      int retries = /*~~>*/flags.getInt("max-retries");
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlagTest.java
+++ b/src/test/java/org/openrewrite/featureflags/quarkus/search/FindFeatureFlagTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.featureflags.quarkus.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class FindFeatureFlagTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath("quarkus-flags"));
+    }
+
+    @DocumentExample
+    @Test
+    void findFeatureFlag() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFeatureFlag(null)),
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      boolean flagValue = flags.isEnabled("flag-key-123abc");
+                      if (flagValue) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      boolean flagValue = /*~~>*/flags.isEnabled("flag-key-123abc");
+                      if (flagValue) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findFeatureFlagByName() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFeatureFlag("flag-key-123abc")),
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      boolean flagValue = flags.isEnabled("flag-key-123abc");
+                      if (flagValue) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                      boolean flagValue2 = flags.isEnabled("flag-key-789def");
+                      if (flagValue2) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  public void a(Flags flags) {
+                      boolean flagValue = /*~~>*/flags.isEnabled("flag-key-123abc");
+                      if (flagValue) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                      boolean flagValue2 = flags.isEnabled("flag-key-789def");
+                      if (flagValue2) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void findFlagByNameUsingVariable() {
+        rewriteRun(
+          spec -> spec.recipe(new FindFeatureFlag("flag-key-123abc")),
+          //language=java
+          java(
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  private static final String FEATURE_FLAG = "flag-key-123abc";
+                  private static final String FEATURE2_FLAG = "flag-key-789def";
+                  public void a(Flags flags) {
+                      boolean flagValue = flags.isEnabled(FEATURE_FLAG);
+                      if (flagValue) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                      boolean flagValue2 = flags.isEnabled(FEATURE2_FLAG);
+                      if (flagValue2) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                  }
+              }
+              """,
+            """
+              import io.quarkiverse.flags.Flags;
+
+              class Test {
+                  private static final String FEATURE_FLAG = "flag-key-123abc";
+                  private static final String FEATURE2_FLAG = "flag-key-789def";
+                  public void a(Flags flags) {
+                      boolean flagValue = /*~~>*/flags.isEnabled(FEATURE_FLAG);
+                      if (flagValue) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                      boolean flagValue2 = flags.isEnabled(FEATURE2_FLAG);
+                      if (flagValue2) {
+                          // Application code to show the feature
+                      } else {
+                          // The code to run if the feature is off
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add support for Quarkus feature flags (`io.quarkiverse.flags`)
- Implement `RemoveIsEnabled` recipe to remove `Flags.isEnabled()` calls for a specific feature key
- Implement `FindFeatureFlag` recipe to find Quarkus feature flag usages
- Follow the same pattern as other vendors (FF4j, Unleash, OpenFeature, LaunchDarkly)

## Details
Quarkus has added their own feature flags extension as per: 
- https://quarkus.io/blog/quarkus-feature-flags/
- https://github.com/quarkiverse/quarkus-flags/blob/1.0.0.Beta5/core/runtime/src/main/java/io/quarkiverse/flags/Flags.java

The core interface is `io.quarkiverse.flags.Flags` with the method `isEnabled(String featureName)` which returns a boolean.

## Test plan
- [x] Unit tests for `RemoveIsEnabled` recipe
- [x] Unit tests for `FindFeatureFlag` recipe (3 test cases: find all, find by name, find by name using constant)
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)