### PR TITLE
use assertj-core provided by `org.openrewrite.build.recipe-library` 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
 
-    implementation("org.assertj:assertj-core:3.27.4")
     testImplementation("org.openrewrite:rewrite-java-21")
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-gradle")


### PR DESCRIPTION
The plugin provides assertj-core with correct scope so we can simply remove this one to drop vulnerability impact