### PR TITLE
Remove redundant junit-jupiter-engine test runtime dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     testImplementation("org.ff4j:ff4j-core:2.0.0") // 2.1.x requires Java 21
 
     testRuntimeOnly("com.launchdarkly:launchdarkly-java-server-sdk:5.+")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.+")
     testRuntimeOnly(gradleApi())
 }
 


### PR DESCRIPTION
## Summary
- JUnit Jupiter engine is now brought in transitively via `rewrite-test` (resolved to 6.1.0 via `junit-bom`), so the explicit `5.+` declaration was redundant and misleading.
- Verified the project still builds cleanly against the new `rewrite-build-gradle-plugin` release and the new openrewrite/rewrite snapshot with `rewrite-test` changes.

## Test plan
- [x] `./gradlew clean test` passes